### PR TITLE
Clarify payloadCreator and metaCreator arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ Create a promise action using `createPromiseAction`, analogous to  [`createActio
 ```js
 import { createPromiseAction } from '@adobe/redux-saga-promise'
 
-export const myAction = createPromiseAction('MY_ACTION')
+export const myAction = createPromiseAction('MY_ACTION') 
+                  // or createPromiseAction('MY_ACTION', payloadCreator)
+                  // or createPromiseAction('MY_ACTION', payloadCreator, metaCreator)
 ```
 
 Behind the scenes, `createPromiseAction` uses `createAction` to define
-[FSA](https://github.com/acdlite/flux-standard-action)-compliant actions.
-It also accepts `payload` and `meta` as optional second and third
-arguments, same as `createAction`.  (And, like `createAction`, technically
+[FSA](https://github.com/acdlite/flux-standard-action)-compliant actions, with the same [optional `payloadCreator`](https://redux-actions.js.org/api/createaction#createactiontype-payloadcreator) and [`metaCreator` arguments](https://redux-actions.js.org/api/createaction#createactiontype-payloadcreator-metacreator).
+(And, like `createAction`, technically
 `createPromiseAction` returns an action *creator* rather than an action.)
 
 ## Dispatching a promise action:

--- a/src/index.js
+++ b/src/index.js
@@ -35,17 +35,17 @@ export class ConfigurationError extends Error {}
 //
 // createPromiseAction() creates the suite of actions
 //
-// The trigger action uses the passed payload & meta functions, and it
+// The trigger action uses the passed payloadCreator & metaCreator functions, and it
 // appends a `promise` object to the meta.  The promise object includes the
 // other lifecycle actions of the suite for use by the middleware; and
 // later on the middleware will add to it functions to resolve and reject
 // the promise.
 //
-export function createPromiseAction (prefix, payload, meta) {
-  const createStage = (type, payload, meta) => createAction(`${prefix}.${type}`, payload, meta)
+export function createPromiseAction (prefix, payloadCreator, metaCreator) {
+  const createStage = (type, payloadCreator, metaCreator) => createAction(`${prefix}.${type}`, payloadCreator, metaCreator)
   const resolvedAction = createStage('RESOLVED')
   const rejectedAction = createStage('REJECTED')
-  const trigger        = createStage('TRIGGER', payload, (...args) => merge(meta?.(...args), { promise: { resolvedAction, rejectedAction } }))
+  const trigger        = createStage('TRIGGER', payloadCreator, (...args) => merge(metaCreator?.(...args), { promise: { resolvedAction, rejectedAction } }))
   const suite    = trigger
   suite.trigger  = trigger
   suite.resolved = resolvedAction

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -279,11 +279,11 @@ test('rejectPromiseAction-ConfigurationError', t => {
   t.assert(caughtMiddlewareError() instanceof ConfigurationError)
 })
 
-test('promiseCreator-and-metaCreator', t => {
+test('payloadCreator-and-metaCreator', t => {
   const actionCreator = createPromiseAction(
     'creators',
-    (payload, meta) => ({ value: payload }),
-    (payload, meta) => ({ attr: meta }),
+    (a, b) => ({ value: a }),   // payloadCreator
+    (a, b) => ({ attr: b }),    // metaCreator
   )
   const action = actionCreator(4, 5)
   t.assert(action.payload.value === 4)

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -278,3 +278,14 @@ test('rejectPromiseAction-ConfigurationError', t => {
   store.dispatch(sagas.controlAction({}))
   t.assert(caughtMiddlewareError() instanceof ConfigurationError)
 })
+
+test('promiseCreator-and-metaCreator', t => {
+  const actionCreator = createPromiseAction(
+    'creators',
+    (payload, meta) => ({ value: payload }),
+    (payload, meta) => ({ attr: meta }),
+  )
+  const action = actionCreator(4, 5)
+  t.assert(action.payload.value === 4)
+  t.assert(action.meta.attr === 5)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the README, make it clearer that `createPromiseAction()` takes the same `payloadCreator` and `metaCreator` arguments as `createAction()`.

Also in the code rename those arguments to `payloadCreator` and `metaCreator` for consistency.   And added a test to verify it all works.

## Related Issue

#5 

## Motivation and Context

N/A

## How Has This Been Tested?

Test suite

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
